### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/coverage/lcov-report/sorter.js
+++ b/coverage/lcov-report/sorter.js
@@ -1,4 +1,14 @@
 /* eslint-disable */
+// Helper to encode HTML entities to prevent XSS
+function escapeHtml(str) {
+    if (typeof str !== 'string') return str;
+    return str
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+       .replace(/'/g, "&#39;");
+}
 var addSorting = (function() {
     'use strict';
     var cols,
@@ -102,6 +112,8 @@ var addSorting = (function() {
             val = colNode.getAttribute('data-value');
             if (col.type === 'number') {
                 val = Number(val);
+            } else {
+                val = escapeHtml(val);
             }
             data[col.key] = val;
         }


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/react-chess/security/code-scanning/1](https://github.com/RumenDamyanov/react-chess/security/code-scanning/1)

The problem is that `colNode.getAttribute('data-value')` can contain attacker-supplied content that, if interpreted as HTML later (for example, if inserted via `innerHTML`), could allow an XSS attack. To mitigate this, **when using or displaying the data in a way that can be interpreted as HTML (typically with `innerHTML` or similar APIs), always perform proper escaping**.

However, the data-flow shown in the snippet appears to mostly manipulate objects for sorting and not for HTML rendering. The only part of the code that writes HTML is in `loadColumns`, which modifies header columns but not the data-values. If at any point, however, these data values are inserted as HTML (which may happen outside this snippet), they need to be escaped. Since we're instructed to fix the original source of taint and be defensive, we should escape the value **as soon as we read it**.

Thus, the **best fix** is to escape `val` as we read it, preventing any accidental unsafe use downstream. We'll add a small helper function to encode HTML entities and apply it to any string value as it's read. The function will only escape string values (not numbers, as columns of type 'number' are converted right after). We'll add this helper function at the top of the file, and update the `loadRowData` function accordingly.

No new dependencies are needed for this simple string escaping.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
